### PR TITLE
パスワードリセットを管理者に限定する

### DIFF
--- a/laravel-project/app/Http/Controllers/Auth/PasswordResetLinkController.php
+++ b/laravel-project/app/Http/Controllers/Auth/PasswordResetLinkController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers\Auth;
 
 use App\Http\Controllers\Controller;
+use App\Models\User;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Password;
@@ -28,6 +29,11 @@ class PasswordResetLinkController extends Controller
         $request->validate([
             'email' => ['required', 'email'],
         ]);
+
+        $user = User::where('email', $request->email)->first();
+        if (is_null($user) || $user->is_admin === 0) {
+            abort(403);
+        }
 
         // We will send the password reset link to this user. Once we have attempted
         // to send the link, we will examine the response then see the message we

--- a/laravel-project/resources/views/auth/login.blade.php
+++ b/laravel-project/resources/views/auth/login.blade.php
@@ -33,11 +33,11 @@
         </div>
 
         <div class="flex items-center justify-end mt-4">
-            @if (Route::has('password.request'))
+            {{-- @if (Route::has('password.request'))
                 <a class="underline text-sm text-gray-600 hover:text-gray-900 rounded-md focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500" href="{{ route('password.request') }}">
                     {{ __('Forgot your password?') }}
                 </a>
-            @endif
+            @endif --}}
 
             <x-primary-button class="ms-3">
                 {{ __('Log in') }}

--- a/laravel-project/resources/views/auth/login.blade.php
+++ b/laravel-project/resources/views/auth/login.blade.php
@@ -33,12 +33,6 @@
         </div>
 
         <div class="flex items-center justify-end mt-4">
-            {{-- @if (Route::has('password.request'))
-                <a class="underline text-sm text-gray-600 hover:text-gray-900 rounded-md focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500" href="{{ route('password.request') }}">
-                    {{ __('Forgot your password?') }}
-                </a>
-            @endif --}}
-
             <x-primary-button class="ms-3">
                 {{ __('Log in') }}
             </x-primary-button>


### PR DESCRIPTION
Laravel Breezeのパスワードリセット機能を使えるのは管理者だけに限定しました。
一般ユーザーのパスワードの変更は管理者が行うからです。

ログイン画面のリンクは削除しました。
URLを直接入力するか、ブックマークに登録してもらいます。

アクセス不可の場合は403エラーに誘導するようにしました。

<img width="455" alt="勤怠管理2024052905" src="https://github.com/gp-sato/kintai/assets/99707520/8700cd40-9d95-4ccc-8618-3f89f46407d1">
<img width="791" alt="勤怠管理2024052906" src="https://github.com/gp-sato/kintai/assets/99707520/e41edb82-10df-4d9b-8144-4cdfa2686d97">
<img width="314" alt="勤怠管理2024052907" src="https://github.com/gp-sato/kintai/assets/99707520/3a0e8498-c103-4775-abef-9139e0dfad62">
