### PR TITLE
#20 viteのポートを開ける

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -4,6 +4,8 @@ services:
     build: ./docker/php
     volumes:
       - .:/var/www
+    ports:
+      - 5173:5173
   nginx:
     image: nginx
     container_name: nginx

--- a/laravel-project/package.json
+++ b/laravel-project/package.json
@@ -2,7 +2,7 @@
     "private": true,
     "type": "module",
     "scripts": {
-        "dev": "vite",
+        "dev": "vite --host",
         "build": "vite build"
     },
     "devDependencies": {

--- a/laravel-project/vite.config.js
+++ b/laravel-project/vite.config.js
@@ -11,4 +11,11 @@ export default defineConfig({
             refresh: true,
         }),
     ],
+
+    server: {
+        host: true,
+        hmr: {
+            host: 'localhost',
+        },
+    },
 });


### PR DESCRIPTION
viteのポートを開けることで、
`npm run dev`
実行時に表示が崩れる問題を解決しました。