### PR TITLE
本番環境用_管理者のみ作成するシーダー

### DIFF
--- a/laravel-project/database/seeders/OnlyAdminSeeder.php
+++ b/laravel-project/database/seeders/OnlyAdminSeeder.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\User;
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+
+class OnlyAdminSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        User::factory()->create([
+            'name' => 'gp-admin',
+            'email' => 'admin@example.com',
+            'is_admin' => 1,
+        ]);
+    }
+}


### PR DESCRIPTION
本番環境構築時に使用するUserモデル用シーダーを作成しました。
管理者1名のみが作成されます。
TruncateAllTablesを実行した後に、OnlyAdminSeederを実行してください。