### PR TITLE
indexページへ戻るボタン追加

### DIFF
--- a/laravel-project/app/Http/Controllers/Admin/AttendanceController.php
+++ b/laravel-project/app/Http/Controllers/Admin/AttendanceController.php
@@ -51,8 +51,8 @@ class AttendanceController extends Controller
         $attendance = new Attendance();
         $attendance->user_id = $user->id;
         $attendance->working_day = $request['working_day'];
-        $attendance->start_time = Carbon::create($request['labor_year'], $request['labor_monath'], $request['labor_day'], $request['start_hour'], $request['start_minute']);
-        $attendance->finish_time = Carbon::create($request['labor_year'], $request['labor_monath'], $request['labor_day'], $request['finish_hour'], $request['finish_minute']);
+        $attendance->start_time = Carbon::create($request['labor_year'], $request['labor_month'], $request['labor_day'], $request['start_hour'], $request['start_minute']);
+        $attendance->finish_time = Carbon::create($request['labor_year'], $request['labor_month'], $request['labor_day'], $request['finish_hour'], $request['finish_minute']);
         $attendance->save();
 
         return redirect()->route('admin.attendance.index', ['user' => $user, 'year' => $request['labor_year'], 'month' => $request['labor_month']]);

--- a/laravel-project/resources/views/admin/administrator/edit.blade.php
+++ b/laravel-project/resources/views/admin/administrator/edit.blade.php
@@ -6,6 +6,10 @@
   </x-slot>
 
   <div class="my-container">
+    <div class="py-4 text-right">
+      <a href="{{ route('admin.index') }}"><button>戻る</button></a>
+    </div>
+
     <form method="POST" action="{{ route('admin.administrator.confirm') }}">
       @csrf
   

--- a/laravel-project/resources/views/admin/user/create.blade.php
+++ b/laravel-project/resources/views/admin/user/create.blade.php
@@ -6,6 +6,10 @@
   </x-slot>
 
   <div class="my-container">
+    <div class="py-4 text-right">
+      <a href="{{ route('admin.index') }}"><button>戻る</button></a>
+    </div>
+
     <form method="POST" action="{{ route('admin.user.confirmCreate') }}">
       @csrf
   

--- a/laravel-project/resources/views/admin/user/edit.blade.php
+++ b/laravel-project/resources/views/admin/user/edit.blade.php
@@ -6,6 +6,10 @@
   </x-slot>
 
   <div class="my-container">
+    <div class="py-4 text-right">
+      <a href="{{ route('admin.index') }}"><button>戻る</button></a>
+    </div>
+
     <form method="POST" action="{{ route('admin.user.confirmEdit', $user) }}">
       @csrf
   


### PR DESCRIPTION
ユーザー新規登録、ユーザー編集、管理者編集、それぞれの画面に管理者インデックスページへの戻るボタンを付けました。
ブラウザバックする必要がなくなりました。

ユーザー編集のみセッションが残ってしまうのですが、最初にセッション破棄の手続きを必ず入れているので、問題ないと思います。